### PR TITLE
White color text even in light mode

### DIFF
--- a/Sources/NewIcon/Subcommands/TextCommand.swift
+++ b/Sources/NewIcon/Subcommands/TextCommand.swift
@@ -84,5 +84,6 @@ private struct IconTextView: View {
                     )
                     .alignmentGuide(VerticalAlignment.center) { $0.height / 2 - 184 }
             )
+            .environment(\.colorScheme, .dark)
     }
 }


### PR DESCRIPTION
# What

- resolve #1 

# How

Since we are using SwiftUI as a template, default text color follows system color scheme, so we were getting white text in dark mode, but black text in light mode. 

Fixed by overriding preferred color scheme.